### PR TITLE
Fixes #203 Topics can be followed via ActivityPub

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -134,6 +134,28 @@ class TopicsController < InheritedResources::Base
     end
   end
 
+  def actor
+    @topic = Topic.from_param(params[:id])
+    render json: @topic.actor_json
+  end
+
+  def inbox
+    @topic = Topic.from_param(params[:id])
+    headers = request.headers.env.reject { |key| key.to_s.include?('.') }
+    post_body = request.raw_post
+    Rails.logger.info "headers = #{headers.inspect}"
+    Rails.logger.info "body = #{post_body}"
+    result, message = @topic.add_to_inbox!(headers, post_body)
+    unless result
+      raise message
+    end
+    render json: {message: message}, status: (result ? 200 : 400)
+  end
+
+  def outbox
+    @topic = Topic.from_param(params[:id])
+  end
+
   protected
   def resource
     @topic = Topic.from_param(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -179,16 +179,25 @@ end
     if username.split(":").first != 'acct'
       error = "acct prefix not found in #{query}"
     end
-    userid = username.split(":").last.gsub("_","-")
-    @user = User.find(userid)
-    if @user.nil?
-      error = "user #{query} not found"
+
+    if username.split(":").last.start_with?("topic-")
+      topicid = username.split(":").last.gsub("topic-","").gsub("_","-")
+      @topic = Topic.where(id: topicid).first
+      if @topic.nil?
+        error = "topic #{query} not found"
+      end
+    else
+      userid = username.split(":").last.gsub("_","-")
+      @user = User.find(userid)
+      if @user.nil?
+        error = "user #{query} not found"
+      end
     end
 
     if error.present?
       render json: {error: error}, status: :not_found
     else
-      render json: @user.webfinger_json
+      render json: (@user || @topic).webfinger_json
     end
 
   end

--- a/app/jobs/activity_pub_follow_accepted_job.rb
+++ b/app/jobs/activity_pub_follow_accepted_job.rb
@@ -1,9 +1,13 @@
 class ActivityPubFollowAcceptedJob < ApplicationJob
   queue_as :default
 
-  def perform(activity_pub_follower_id)
+  def perform(activity_pub_follower_id, model_type)
     begin
-      apf = ActivityPubFollower.find(activity_pub_follower_id)
+      if model_type == 'topic'
+        apf = TopicActivityPubFollower.find(activity_pub_follower_id)
+      else # 'user'
+        apf = ActivityPubFollower.find(activity_pub_follower_id)
+      end
       apf.accept_follow_request!
     rescue Exception => ex
       Rails.logger.error "Error #{ex.message} in ActivityPubFollowAcceptedJob for #{activity_pub_follower_id}"

--- a/app/models/topic_activity_pub_follower.rb
+++ b/app/models/topic_activity_pub_follower.rb
@@ -1,0 +1,61 @@
+require 'json'
+require 'httparty'
+
+class TopicActivityPubFollower < ApplicationRecord
+  belongs_to :topic
+  validates_presence_of :user
+  validates_presence_of :metadata
+  validates_uniqueness_of :metadata
+
+  def inbox
+    data = JSON.parse(self.metadata)
+    actor = JSON.parse(HTTParty.get(data["actor"], headers: {'Accept': 'application/json'}).body.to_s)
+    full_inbox = actor["inbox"]
+  end
+
+  def actor
+    data = JSON.parse(self.metadata)
+    data["actor"]
+  end
+
+  def object
+    data = JSON.parse(self.metadata)
+    data["object"]
+  end
+
+  def accept_follow_request!
+    data = JSON.parse(self.metadata)
+
+    doc = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Accept",
+      "actor": Rails.application.routes.url_helpers.actor_topic_url(self.user),
+
+      "object": {
+        "type": data["type"],
+        "actor": data["actor"],
+        "object": data["object"]
+      }
+    }
+
+    full_inbox = self.inbox
+    date = Time.now.utc.httpdate
+
+    signature_header = ActivityPub.sign(
+      Rails.application.routes.url_helpers.actor_topic_url(self.topic),
+      URI.parse(full_inbox).path,
+      URI.parse(full_inbox).host,
+      date,
+      ENV['ACTIVITYPUB_PRIVKEY'].to_s
+    )
+
+    HTTParty.post(full_inbox,
+      body: doc.to_json,
+      headers: { 'Date': date, 'Signature': signature_header , 'Content-Type': 'application/json'}
+    )
+  end
+
+  def accept_unfollow_request!
+    #TODO
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,10 +233,10 @@ class User < ApplicationRecord
 
 	  if body_hash["object"] == actor_url and ActivityPub.verify(nil, all_headers, inbox_path)
 	  	if body_hash["type"] == "Follow" # Do this check first
-	  		Rails.logger.info "New follow from ActivityPub for #{self.id}"
+	  		Rails.logger.info "New follow from ActivityPub for user #{self.id}"
 	  		afp = self.activity_pub_followers.create!(metadata: body)
 	  		# Send Accept response
-			ActivityPubFollowAcceptedJob.perform_later(afp.id)
+			ActivityPubFollowAcceptedJob.perform_later(afp.id, 'user')
 			return true, "Follow accepted"
 		elsif body_hash["type"] == "Unfollow" # Do this check first
 			Rails.logger.info "Unfollow request from ActivityPub for #{self.id}: #{body_hash.inspect}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
       post 'wiki_update'
       get 'practice'
       post 'practice'
+      get 'actor'
+      post 'inbox'
+      get 'outbox'
     end
     collection do
       get 'search'

--- a/db/migrate/20200930190125_create_topic_activity_pub_followers.rb
+++ b/db/migrate/20200930190125_create_topic_activity_pub_followers.rb
@@ -1,0 +1,10 @@
+class CreateTopicActivityPubFollowers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :topic_activity_pub_followers, id: :uuid do |t|
+      t.references :topic, null: false, foreign_key: true, type: :uuid
+      t.text :metadata, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -237,8 +223,7 @@ CREATE TABLE public.idea_sets (
     name character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    description text,
-    is_approved boolean DEFAULT false NOT NULL
+    description text
 );
 
 
@@ -429,7 +414,9 @@ CREATE TABLE public.schema_migrations (
 
 CREATE TABLE public.slack_authorizations (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    token json NOT NULL
+    token json NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -441,7 +428,9 @@ CREATE TABLE public.slack_subscriptions (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     slack_authorization_id uuid NOT NULL,
     channel_id character varying NOT NULL,
-    topic_id uuid NOT NULL
+    topic_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -455,6 +444,19 @@ CREATE TABLE public.social_logins (
     auth0_info json,
     post_reviews boolean DEFAULT true NOT NULL,
     user_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: topic_activity_pub_followers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.topic_activity_pub_followers (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    topic_id uuid NOT NULL,
+    metadata text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -817,6 +819,14 @@ ALTER TABLE ONLY public.social_logins
 
 
 --
+-- Name: topic_activity_pub_followers topic_activity_pub_followers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.topic_activity_pub_followers
+    ADD CONSTRAINT topic_activity_pub_followers_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: topic_idea_sets topic_idea_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1134,6 +1144,13 @@ CREATE INDEX index_social_logins_on_user_id ON public.social_logins USING btree 
 
 
 --
+-- Name: index_topic_activity_pub_followers_on_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_topic_activity_pub_followers_on_topic_id ON public.topic_activity_pub_followers USING btree (topic_id);
+
+
+--
 -- Name: index_topic_idea_sets_on_idea_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1302,6 +1319,14 @@ ALTER TABLE ONLY public.slack_subscriptions
 
 ALTER TABLE ONLY public.user_user_relations
     ADD CONSTRAINT fk_rails_10bcd883e4 FOREIGN KEY (from_user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: topic_activity_pub_followers fk_rails_14e820a7ac; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.topic_activity_pub_followers
+    ADD CONSTRAINT fk_rails_14e820a7ac FOREIGN KEY (topic_id) REFERENCES public.topics(id);
 
 
 --
@@ -1656,7 +1681,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200730185439'),
 ('20200824210734'),
 ('20200824230523'),
-('20200825025845'),
-('20200922144058');
+('20200922144058'),
+('20200930190125');
 
 

--- a/test/fixtures/topic_activity_pub_followers.yml
+++ b/test/fixtures/topic_activity_pub_followers.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  topic_id: one
+  metadata: MyText
+
+two:
+  topic_id: two
+  metadata: MyText

--- a/test/models/topic_activity_pub_follower_test.rb
+++ b/test/models/topic_activity_pub_follower_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TopicActivityPubFollowerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR implements #203 

Just like User, now Topics too can have  a webfinger response, an actor response, an inbox url, and a `add_to_inbox!` method that accepts activities. Topic followers are stored in `TopicActivityPubFollower` model. `ActivityPubFollowerJob` is reused with the help of a method parameter.